### PR TITLE
WEBDEV-5688 Hint that soft keyboard should be search-focused and dismiss on submit

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     html {
       font-size: 10px; /* This is to match petabox's base font size */

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -50,6 +50,7 @@ export class IaClearableTextInput extends LitElement {
           type="text"
           inputmode="search"
           enterkeyhint="search"
+          autocapitalize="off"
           placeholder=${this.placeholder ?? nothing}
           .value=${this.value ?? nothing}
           aria-controls=${this.ariaControls ?? nothing}

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -48,6 +48,8 @@ export class IaClearableTextInput extends LitElement {
         <input
           id="text-input"
           type="text"
+          inputmode="search"
+          enterkeyhint="search"
           placeholder=${this.placeholder ?? nothing}
           .value=${this.value ?? nothing}
           aria-controls=${this.ariaControls ?? nothing}

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -81,6 +81,9 @@ export class IaClearableTextInput extends LitElement {
     // form element, we emit this event so that parent components don't need to listen for
     // arbitrary key events just for this single use case.
     if (e.key === 'Enter') {
+      // Blur the input field
+      this.textInput.blur();
+
       const submitEvent = new CustomEvent<string>('submit', {
         detail: this.value,
       });

--- a/test/ia-clearable-text-input.test.ts
+++ b/test/ia-clearable-text-input.test.ts
@@ -1,4 +1,5 @@
 import { html, fixture, expect } from '@open-wc/testing';
+import sinon from 'sinon';
 
 import type { IaClearableTextInput } from '../src/ia-clearable-text-input';
 import '../src/ia-clearable-text-input';
@@ -116,6 +117,26 @@ describe('Clearable text input', () => {
     expect(clearableTextInput.shadowRoot?.activeElement).to.not.equal(
       inputField
     );
+  });
+
+  it('blurs and emits submit event upon hitting enter', async () => {
+    const submitSpy = sinon.spy();
+    clearableTextInput = await fixture<IaClearableTextInput>(
+      html`<ia-clearable-text-input
+        .value=${'a'}
+        @submit=${submitSpy}
+      ></ia-clearable-text-input>`
+    );
+
+    inputField = clearableTextInput.shadowRoot?.querySelector(
+      '#text-input'
+    ) as HTMLInputElement;
+
+    inputField.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+    await clearableTextInput.updateComplete;
+
+    expect(submitSpy.callCount).to.equal(1);
+    expect(clearableTextInput.shadowRoot?.activeElement).not.to.exist; // No focused element
   });
 
   it('accepts optional properties', async () => {


### PR DESCRIPTION
Adds hint attributes to the input field to indicate that mobile soft keyboards should use their "search" layouts/action labels, and ensures that the input field is blurred upon submitting a query (which should dismiss any open soft keyboard).