### PR TITLE
WEBDEV-6292 Add property & slot for inline profile page usage

### DIFF
--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -38,11 +38,17 @@ export class IaClearableTextInput extends LitElement {
    */
   @property({ type: Boolean }) focusOnClear = true;
 
+  /**
+   * If true, the clear button will be shown regardless of whether there is any
+   * text entered in the input field.
+   */
+  @property({ type: Boolean }) forceClearButton = false;
+
   @query('#text-input')
   private textInput!: HTMLInputElement;
 
   protected render(): TemplateResult {
-    const hideClearButton = !this.value;
+    const hideClearButton = !this.value && !this.forceClearButton;
     return html`
       <div id="container">
         <input

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -2,8 +2,6 @@ import { html, css, nothing, LitElement, TemplateResult } from 'lit';
 import { property, query, customElement } from 'lit/decorators.js';
 import '@internetarchive/icon-close';
 
-type FocusOptions = Parameters<HTMLElement['focus']>[0];
-
 @customElement('ia-clearable-text-input')
 export class IaClearableTextInput extends LitElement {
   /**
@@ -48,6 +46,13 @@ export class IaClearableTextInput extends LitElement {
 
   @query('#text-input')
   private textInput!: HTMLInputElement;
+
+  // Options to pass in when creating the shadow root.
+  // This ensures that focusing the component delegates focus to the search bar.
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
 
   protected render(): TemplateResult {
     const hideClearButton = !this.value && !this.forceClearButton;
@@ -126,13 +131,6 @@ export class IaClearableTextInput extends LitElement {
       inputType: 'deleteContentBackward',
     });
     this.dispatchEvent(inputEvent);
-  }
-
-  /**
-   * Overrides the base element focus method to redirect focus to the input
-   */
-  override focus(options?: FocusOptions): void {
-    this.textInput.focus(options);
   }
 
   static styles = css`

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -49,8 +49,10 @@ export class IaClearableTextInput extends LitElement {
 
   protected render(): TemplateResult {
     const hideClearButton = !this.value && !this.forceClearButton;
+
     return html`
       <div id="container">
+        <slot name="icon"></slot>
         <input
           id="text-input"
           type="text"

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -2,6 +2,8 @@ import { html, css, nothing, LitElement, TemplateResult } from 'lit';
 import { property, query, customElement } from 'lit/decorators.js';
 import '@internetarchive/icon-close';
 
+type FocusOptions = Parameters<HTMLElement['focus']>[0];
+
 @customElement('ia-clearable-text-input')
 export class IaClearableTextInput extends LitElement {
   /**
@@ -124,6 +126,13 @@ export class IaClearableTextInput extends LitElement {
       inputType: 'deleteContentBackward',
     });
     this.dispatchEvent(inputEvent);
+  }
+
+  /**
+   * Overrides the base element focus method to redirect focus to the input
+   */
+  override focus(options?: FocusOptions): void {
+    this.textInput.focus(options);
   }
 
   static styles = css`

--- a/src/ia-clearable-text-input.ts
+++ b/src/ia-clearable-text-input.ts
@@ -44,7 +44,7 @@ export class IaClearableTextInput extends LitElement {
    * If true, the clear button will be shown regardless of whether there is any
    * text entered in the input field.
    */
-  @property({ type: Boolean }) forceClearButton = false;
+  @property({ type: Boolean, reflect: true }) forceClearButton = false;
 
   @query('#text-input')
   private textInput!: HTMLInputElement;

--- a/test/ia-clearable-text-input.test.ts
+++ b/test/ia-clearable-text-input.test.ts
@@ -22,6 +22,18 @@ describe('Clearable text input', () => {
     expect(clearButton?.hidden).to.equal(true);
   });
 
+  it('shows the clear button when forced by property, even without text', async () => {
+    clearableTextInput = await fixture<IaClearableTextInput>(
+      html`<ia-clearable-text-input forceClearButton></ia-clearable-text-input>`
+    );
+    await clearableTextInput.updateComplete;
+
+    clearButton = clearableTextInput.shadowRoot?.querySelector(
+      '#clear-button'
+    ) as HTMLButtonElement;
+    expect(clearButton?.hidden).to.equal(false);
+  });
+
   it('shows the clear button when the input field has initial text', async () => {
     clearableTextInput = await fixture<IaClearableTextInput>(
       html`<ia-clearable-text-input .value=${'a'}></ia-clearable-text-input>`


### PR DESCRIPTION
Adds the `forceClearButton` property allowing the parent to specify that the component should display its close button even when there is no text entered within it. Also adds a named `icon` slot to the left of the input bar, and ensures that calling `.focus()` on the component will in turn focus the input bar.